### PR TITLE
setup script

### DIFF
--- a/apps/dashboard/src/environments/environment.prod.ts
+++ b/apps/dashboard/src/environments/environment.prod.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: true,
-  apiHost: 'http://localhost:3000',
+  apiHost: 'https://wlj3ikt283.execute-api.ap-southeast-2.amazonaws.com/Sta/',
 };

--- a/apps/deployment/src/main.ts
+++ b/apps/deployment/src/main.ts
@@ -1,4 +1,4 @@
-import { App, CfnParameter, Environment } from '@aws-cdk/core';
+import { App, Environment } from '@aws-cdk/core';
 import {
   DatabaseStack,
   HttpStack,
@@ -13,16 +13,6 @@ const env: Environment = {
 };
 const app = new App();
 
-const CodeArtifactDomainName = new CfnParameter(app, 'CodeArtifactDomainName', {
-  type: 'String',
-  description: 'Domain name of CodeArtifact',
-});
-
-const GithubOrgName = new CfnParameter(app, 'GithubOrgName', {
-  type: 'String',
-  description: 'Github Organization Name',
-});
-
 for (const stageName of ['Sta' /*, 'Prd' */]) {
   const database = new DatabaseStack(app, `${stageName}Database`, { env });
 
@@ -32,23 +22,20 @@ for (const stageName of ['Sta' /*, 'Prd' */]) {
     stageName,
   });
 
+  const codeArtifact = new CodeArtifactStack(app, `${stageName}CodeArtifact`);
+
   const parser = new ParserStack(app, `${stageName}Parser`, {
     env,
     database,
     stageName,
-    codeArtifactDomain: CodeArtifactDomainName,
+    codeArtifactDomain: codeArtifact.CodeArtifactDomainName,
   });
   const parserLambda = parser.lambda;
-
-  new CodeArtifactStack(app, `${stageName}CodeArtifact`, {
-    codeArtifactDomain: CodeArtifactDomainName,
-  });
 
   new HookStack(app, `${stageName}Hooks`, {
     env,
     stageName,
     parserLambda,
-    githubOrg: GithubOrgName,
   });
 
   new DashboardStack(app, `${stageName}Dashboard`);

--- a/apps/deployment/src/main.ts
+++ b/apps/deployment/src/main.ts
@@ -13,7 +13,7 @@ const env: Environment = {
 };
 const app = new App();
 
-for (const stageName of ['Sta' /*, 'Prd' */]) {
+for (const stageName of ['Dev' /*, 'Prd' */]) {
   const database = new DatabaseStack(app, `${stageName}Database`, { env });
 
   new HttpStack(app, `${stageName}Http`, {
@@ -22,13 +22,15 @@ for (const stageName of ['Sta' /*, 'Prd' */]) {
     stageName,
   });
 
-  const codeArtifact = new CodeArtifactStack(app, `${stageName}CodeArtifact`);
+  new CodeArtifactStack(app, `${stageName}CodeArtifact`, {
+    env,
+    stageName,
+  });
 
   const parser = new ParserStack(app, `${stageName}Parser`, {
     env,
     database,
     stageName,
-    codeArtifactDomain: codeArtifact.CodeArtifactDomainName,
   });
   const parserLambda = parser.lambda;
 
@@ -38,5 +40,5 @@ for (const stageName of ['Sta' /*, 'Prd' */]) {
     parserLambda,
   });
 
-  new DashboardStack(app, `${stageName}Dashboard`);
+  new DashboardStack(app, `${stageName}Dashboard`, { env, stageName });
 }

--- a/apps/deployment/src/main.ts
+++ b/apps/deployment/src/main.ts
@@ -5,6 +5,7 @@ import {
   ParserStack,
   HookStack,
   CodeArtifactStack,
+  DashboardStack,
 } from './stacks';
 
 const env: Environment = {
@@ -49,4 +50,6 @@ for (const stageName of ['Sta' /*, 'Prd' */]) {
     parserLambda,
     githubOrg: GithubOrgName,
   });
+
+  new DashboardStack(app, `${stageName}Dashboard`);
 }

--- a/apps/deployment/src/stacks/codeartifact-stack.ts
+++ b/apps/deployment/src/stacks/codeartifact-stack.ts
@@ -1,39 +1,45 @@
-import { Stack, StackProps, Construct, CfnParameter } from '@aws-cdk/core';
+import { Stack, StackProps, Construct } from '@aws-cdk/core';
 import * as codeArtifact from '@aws-cdk/aws-codeartifact';
 
-export class CodeArtifactStack extends Stack {
-  CodeArtifactDomainName: CfnParameter;
+export interface CodeArtifactStackProps extends StackProps {
+  stageName: string;
+}
 
-  constructor(scope: Construct, id: string, props?: StackProps) {
+export class CodeArtifactStack extends Stack {
+  constructor(scope: Construct, id: string, props: CodeArtifactStackProps) {
     super(scope, id, props);
 
-    this.CodeArtifactDomainName = new CfnParameter(
+    /* this is bucketname for directory */
+    const orgName = this.node.tryGetContext('CodeArtifactDomainName');
+    if (!orgName) throw new Error('CodeArtifactDomainName context undefined');
+    const caDomain = new codeArtifact.CfnDomain(
       this,
-      'CodeArtifactDomainName',
+      `${props.stageName} CA Domain`,
       {
-        type: 'String',
-        description: 'Domain name of CodeArtifact',
+        domainName: orgName,
       }
     );
 
-    /* this is bucketname for directory */
-    const orgName = this.CodeArtifactDomainName.valueAsString;
-    const caDomain = new codeArtifact.CfnDomain(this, 'CA Domain', {
-      domainName: orgName,
-    });
-
-    const publicRepo = new codeArtifact.CfnRepository(this, 'Public Repo', {
-      domainName: caDomain.domainName,
-      repositoryName: 'public-' + orgName,
-      externalConnections: ['public:npmjs'],
-    });
+    const publicRepo = new codeArtifact.CfnRepository(
+      this,
+      `${props.stageName} Public Repo`,
+      {
+        domainName: caDomain.domainName,
+        repositoryName: 'public-' + orgName,
+        externalConnections: ['public:npmjs'],
+      }
+    );
     publicRepo.addDependsOn(caDomain);
 
-    const privateRepo = new codeArtifact.CfnRepository(this, 'Private Repo', {
-      domainName: caDomain.domainName,
-      repositoryName: 'private-' + orgName,
-      upstreams: [publicRepo.repositoryName],
-    });
+    const privateRepo = new codeArtifact.CfnRepository(
+      this,
+      `${props.stageName} Private Repo`,
+      {
+        domainName: caDomain.domainName,
+        repositoryName: 'private-' + orgName,
+        upstreams: [publicRepo.repositoryName],
+      }
+    );
     privateRepo.addDependsOn(publicRepo);
   }
 }

--- a/apps/deployment/src/stacks/codeartifact-stack.ts
+++ b/apps/deployment/src/stacks/codeartifact-stack.ts
@@ -1,12 +1,16 @@
-import { Stack, StackProps, Construct } from '@aws-cdk/core';
+import { Stack, StackProps, Construct, CfnParameter } from '@aws-cdk/core';
 import * as codeArtifact from '@aws-cdk/aws-codeartifact';
 
+export interface CodeArtifactStackProps extends StackProps {
+  codeArtifactDomain: CfnParameter;
+}
+
 export class CodeArtifactStack extends Stack {
-  constructor(scope: Construct, id: string, props?: StackProps) {
+  constructor(scope: Construct, id: string, props?: CodeArtifactStackProps) {
     super(scope, id, props);
 
     /* this is bucketname for directory */
-    const orgName = 'cs9447-team2-demo';
+    const orgName = props.codeArtifactDomain.valueAsString;
     const caDomain = new codeArtifact.CfnDomain(this, 'CA Domain', {
       domainName: orgName,
     });

--- a/apps/deployment/src/stacks/codeartifact-stack.ts
+++ b/apps/deployment/src/stacks/codeartifact-stack.ts
@@ -1,16 +1,23 @@
 import { Stack, StackProps, Construct, CfnParameter } from '@aws-cdk/core';
 import * as codeArtifact from '@aws-cdk/aws-codeartifact';
 
-export interface CodeArtifactStackProps extends StackProps {
-  codeArtifactDomain: CfnParameter;
-}
-
 export class CodeArtifactStack extends Stack {
-  constructor(scope: Construct, id: string, props?: CodeArtifactStackProps) {
+  CodeArtifactDomainName: CfnParameter;
+
+  constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
+    this.CodeArtifactDomainName = new CfnParameter(
+      this,
+      'CodeArtifactDomainName',
+      {
+        type: 'String',
+        description: 'Domain name of CodeArtifact',
+      }
+    );
+
     /* this is bucketname for directory */
-    const orgName = props.codeArtifactDomain.valueAsString;
+    const orgName = this.CodeArtifactDomainName.valueAsString;
     const caDomain = new codeArtifact.CfnDomain(this, 'CA Domain', {
       domainName: orgName,
     });

--- a/apps/deployment/src/stacks/dashboard-stack.ts
+++ b/apps/deployment/src/stacks/dashboard-stack.ts
@@ -1,23 +1,31 @@
-import { Stack, StackProps, Construct } from '@aws-cdk/core';
+import { Stack, StackProps, Construct, CfnOutput } from '@aws-cdk/core';
 import { BucketDeployment, Source } from '@aws-cdk/aws-s3-deployment';
 import { Bucket } from '@aws-cdk/aws-s3';
 import { join } from 'path';
 
+export interface DashboardStackProps extends StackProps {
+  stageName: string;
+}
+
 export class DashboardStack extends Stack {
-  constructor(scope: Construct, id: string, props?: StackProps) {
+  constructor(scope: Construct, id: string, props: DashboardStackProps) {
     super(scope, id, props);
 
     const rootDir = [__dirname, '..', '..', '..', '..'];
     const pathToCode = join(...rootDir, 'dist', 'apps', 'dashboard');
 
-    const bucket = new Bucket(this, 'Bucket', {
+    const bucket = new Bucket(this, `${props.stageName}Bucket`, {
       websiteIndexDocument: 'index.html',
       publicReadAccess: true,
     });
 
-    new BucketDeployment(this, 'Deployment', {
+    new BucketDeployment(this, `${props.stageName}Deployment`, {
       sources: [Source.asset(pathToCode)],
       destinationBucket: bucket,
+    });
+
+    new CfnOutput(this, `${props.stageName}DashboardURL`, {
+      value: bucket.bucketWebsiteUrl,
     });
   }
 }

--- a/apps/deployment/src/stacks/dashboard-stack.ts
+++ b/apps/deployment/src/stacks/dashboard-stack.ts
@@ -1,0 +1,23 @@
+import { Stack, StackProps, Construct } from '@aws-cdk/core';
+import { BucketDeployment, Source } from '@aws-cdk/aws-s3-deployment';
+import { Bucket } from '@aws-cdk/aws-s3';
+import { join } from 'path';
+
+export class DashboardStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    const rootDir = [__dirname, '..', '..', '..', '..'];
+    const pathToCode = join(...rootDir, 'dist', 'apps', 'dashboard');
+
+    const bucket = new Bucket(this, 'Bucket', {
+      websiteIndexDocument: 'index.html',
+      publicReadAccess: true,
+    });
+
+    new BucketDeployment(this, 'Deployment', {
+      sources: [Source.asset(pathToCode)],
+      destinationBucket: bucket,
+    });
+  }
+}

--- a/apps/deployment/src/stacks/hooks-stack.ts
+++ b/apps/deployment/src/stacks/hooks-stack.ts
@@ -14,13 +14,18 @@ import { join } from 'path';
 interface HookStackProps extends StackProps {
   stageName: string;
   parserLambda: lambda.Function;
-  githubOrg: CfnParameter;
 }
 
 export class HookStack extends Stack {
   pipelineLinkerApiURL: string;
+  GithubOrgName: CfnParameter;
   constructor(scope: Construct, id: string, props: HookStackProps) {
     super(scope, id, props);
+
+    this.GithubOrgName = new CfnParameter(this, 'GithubOrgName', {
+      type: 'String',
+      description: 'Github Organization Name',
+    });
 
     // codeArtifactDockerLambda
     const codeArtifactDockerLambdaAppPath = join(
@@ -133,7 +138,7 @@ export class HookStack extends Stack {
         timeout: Duration.seconds(10),
         code: lambda.Code.fromAsset(linkPipelineAppPath),
         environment: {
-          ORG_NAME: props.githubOrg.valueAsString,
+          ORG_NAME: this.GithubOrgName.valueAsString,
           WEBHOOK_URL: pipelineApi.url,
         },
       }

--- a/apps/deployment/src/stacks/http-stack.ts
+++ b/apps/deployment/src/stacks/http-stack.ts
@@ -28,32 +28,40 @@ export class HttpStack extends Stack {
       'http'
     );
 
-    const httpLambda = new NodeLambdaFunc(this, 'HttpHandlerFunc', {
-      code: lambda.Code.fromAsset(pathToCode),
-      environment: {
-        TABLE_NAME: database.table.tableName,
-      },
-    }).LambdaFunction;
+    const httpLambda = new NodeLambdaFunc(
+      this,
+      `${props.stageName}HttpHandlerFunc`,
+      {
+        code: lambda.Code.fromAsset(pathToCode),
+        environment: {
+          TABLE_NAME: database.table.tableName,
+        },
+      }
+    ).LambdaFunction;
 
     database.grantRead(httpLambda);
     database.grantWrite(httpLambda);
 
-    const api = new apiGw.LambdaRestApi(this, 'RESTEndpoint', {
-      handler: httpLambda,
-      proxy: true,
-      deployOptions: {
-        stageName: props.stageName,
-      },
-      description: `REST endpoint for ${props.stageName}`,
-      defaultCorsPreflightOptions: {
-        // TODO: allow only 'frontend' origin
-        allowOrigins: apiGw.Cors.ALL_ORIGINS,
-        allowMethods: apiGw.Cors.ALL_METHODS,
-        allowHeaders: apiGw.Cors.DEFAULT_HEADERS,
-      },
-    });
+    const api = new apiGw.LambdaRestApi(
+      this,
+      `${props.stageName}RESTEndpoint`,
+      {
+        handler: httpLambda,
+        proxy: true,
+        deployOptions: {
+          stageName: props.stageName,
+        },
+        description: `REST endpoint for ${props.stageName}`,
+        defaultCorsPreflightOptions: {
+          // TODO: allow only 'frontend' origin
+          allowOrigins: apiGw.Cors.ALL_ORIGINS,
+          allowMethods: apiGw.Cors.ALL_METHODS,
+          allowHeaders: apiGw.Cors.DEFAULT_HEADERS,
+        },
+      }
+    );
 
-    new CfnOutput(this, 'HTTP_API_URL', {
+    new CfnOutput(this, `${props.stageName}HttpApiURL`, {
       value: api.url ?? 'ERROR: No URL allocated',
     });
 

--- a/apps/deployment/src/stacks/http-stack.ts
+++ b/apps/deployment/src/stacks/http-stack.ts
@@ -53,7 +53,7 @@ export class HttpStack extends Stack {
       },
     });
 
-    new CfnOutput(this, 'API URL', {
+    new CfnOutput(this, 'HTTP_API_URL', {
       value: api.url ?? 'ERROR: No URL allocated',
     });
 

--- a/apps/deployment/src/stacks/index.ts
+++ b/apps/deployment/src/stacks/index.ts
@@ -3,3 +3,4 @@ export * from './parser-stack';
 export * from './database-stack';
 export * from './hooks-stack';
 export * from './codeartifact-stack';
+export * from './dashboard-stack';

--- a/apps/deployment/src/stacks/parser-stack.ts
+++ b/apps/deployment/src/stacks/parser-stack.ts
@@ -1,4 +1,10 @@
-import { Stack, StackProps, Construct, Duration } from '@aws-cdk/core';
+import {
+  Stack,
+  StackProps,
+  Construct,
+  Duration,
+  CfnParameter,
+} from '@aws-cdk/core';
 import * as lambda from '@aws-cdk/aws-lambda';
 import { DatabaseStack } from './database-stack';
 import { join } from 'path';
@@ -8,6 +14,7 @@ import * as iam from '@aws-cdk/aws-iam';
 interface ParserStackProps extends StackProps {
   database: DatabaseStack;
   stageName: string;
+  codeArtifactDomain: CfnParameter;
 }
 
 export class ParserStack extends Stack {
@@ -32,7 +39,7 @@ export class ParserStack extends Stack {
       code: lambda.Code.fromAsset(pathToCode),
       environment: {
         TABLE_NAME: database.table.tableName,
-        DOMAIN: 'cs9447-team2-demo',
+        DOMAIN: props.codeArtifactDomain.valueAsString,
       },
       timeout: Duration.seconds(30),
     }).LambdaFunction;

--- a/apps/deployment/src/stacks/parser-stack.ts
+++ b/apps/deployment/src/stacks/parser-stack.ts
@@ -1,10 +1,4 @@
-import {
-  Stack,
-  StackProps,
-  Construct,
-  Duration,
-  CfnParameter,
-} from '@aws-cdk/core';
+import { Stack, StackProps, Construct, Duration } from '@aws-cdk/core';
 import * as lambda from '@aws-cdk/aws-lambda';
 import { DatabaseStack } from './database-stack';
 import { join } from 'path';
@@ -14,7 +8,6 @@ import * as iam from '@aws-cdk/aws-iam';
 interface ParserStackProps extends StackProps {
   database: DatabaseStack;
   stageName: string;
-  codeArtifactDomain: CfnParameter;
 }
 
 export class ParserStack extends Stack {
@@ -35,14 +28,20 @@ export class ParserStack extends Stack {
       'parser'
     );
 
-    const parserLambda = new NodeLambdaFunc(this, 'ParserHandlerFunc', {
-      code: lambda.Code.fromAsset(pathToCode),
-      environment: {
-        TABLE_NAME: database.table.tableName,
-        DOMAIN: props.codeArtifactDomain.valueAsString,
-      },
-      timeout: Duration.seconds(30),
-    }).LambdaFunction;
+    const domain = this.node.tryGetContext('CodeArtifactDomainName');
+    if (!domain) throw new Error('CodeArtifactDomainName context undefined');
+    const parserLambda = new NodeLambdaFunc(
+      this,
+      `${props.stageName}ParserHandlerFunc`,
+      {
+        code: lambda.Code.fromAsset(pathToCode),
+        environment: {
+          TABLE_NAME: database.table.tableName,
+          DOMAIN: domain,
+        },
+        timeout: Duration.seconds(30),
+      }
+    ).LambdaFunction;
 
     database.grantRead(parserLambda);
     database.grantWrite(parserLambda);

--- a/package-lock.json
+++ b/package-lock.json
@@ -193,6 +193,24 @@
         "constructs": "^3.3.69"
       }
     },
+    "@aws-cdk/aws-cloudfront": {
+      "version": "1.152.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudfront/-/aws-cloudfront-1.152.0.tgz",
+      "integrity": "sha512-9tBIRfIvtf58DSB54dDleWC5RkJhC6A9l/t6uzOuprpgklYR0iLmKjqAB08L99RBvvfsdQhwdbcP7ISEmtGUrA==",
+      "requires": {
+        "@aws-cdk/aws-certificatemanager": "1.152.0",
+        "@aws-cdk/aws-cloudwatch": "1.152.0",
+        "@aws-cdk/aws-ec2": "1.152.0",
+        "@aws-cdk/aws-iam": "1.152.0",
+        "@aws-cdk/aws-kms": "1.152.0",
+        "@aws-cdk/aws-lambda": "1.152.0",
+        "@aws-cdk/aws-s3": "1.152.0",
+        "@aws-cdk/aws-ssm": "1.152.0",
+        "@aws-cdk/core": "1.152.0",
+        "@aws-cdk/cx-api": "1.152.0",
+        "constructs": "^3.3.69"
+      }
+    },
     "@aws-cdk/aws-cloudwatch": {
       "version": "1.152.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.152.0.tgz",
@@ -472,6 +490,31 @@
         "constructs": "^3.3.69"
       }
     },
+    "@aws-cdk/aws-s3-deployment": {
+      "version": "1.152.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-deployment/-/aws-s3-deployment-1.152.0.tgz",
+      "integrity": "sha512-+4WDJHBBr7TeDHhzudlz1l55DUSI7q2uSMuzhRy5dEfZTtQFuf5qzS7Fz+LXP51Nn9/8vuAUeDsxs/Wl3mRoSA==",
+      "requires": {
+        "@aws-cdk/aws-cloudfront": "1.152.0",
+        "@aws-cdk/aws-ec2": "1.152.0",
+        "@aws-cdk/aws-efs": "1.152.0",
+        "@aws-cdk/aws-iam": "1.152.0",
+        "@aws-cdk/aws-lambda": "1.152.0",
+        "@aws-cdk/aws-logs": "1.152.0",
+        "@aws-cdk/aws-s3": "1.152.0",
+        "@aws-cdk/aws-s3-assets": "1.152.0",
+        "@aws-cdk/core": "1.152.0",
+        "@aws-cdk/lambda-layer-awscli": "1.152.0",
+        "case": "1.6.3",
+        "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "case": {
+          "version": "1.6.3",
+          "bundled": true
+        }
+      }
+    },
     "@aws-cdk/aws-s3-notifications": {
       "version": "1.152.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-notifications/-/aws-s3-notifications-1.152.0.tgz",
@@ -732,6 +775,16 @@
           "version": "4.0.0",
           "bundled": true
         }
+      }
+    },
+    "@aws-cdk/lambda-layer-awscli": {
+      "version": "1.152.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/lambda-layer-awscli/-/lambda-layer-awscli-1.152.0.tgz",
+      "integrity": "sha512-1ek52jalCDoXgdfbUFCDmqV9t7ndOeN7AE6IZZJSbcq91Nl3/Hfxex/ktc73nCOjOC0xBJDKxmzz1iTM2eO2mQ==",
+      "requires": {
+        "@aws-cdk/aws-lambda": "1.152.0",
+        "@aws-cdk/core": "1.152.0",
+        "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/region-info": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@aws-cdk/aws-codeartifact": "^1.150.0",
     "@aws-cdk/aws-dynamodb": "^1.150.0",
     "@aws-cdk/aws-s3": "^1.150.0",
+    "@aws-cdk/aws-s3-deployment": "^1.152.0",
     "@aws-cdk/aws-s3-notifications": "^1.150.0",
     "@aws-cdk/core": "^1.127.0",
     "@aws-sdk/client-s3": "^3.72.0",

--- a/setup.sh
+++ b/setup.sh
@@ -25,8 +25,6 @@ read -p "AWS Access Key ID: " AWS_ACCESS_KEY_ID
 read -p "AWS Secret Access Key: " AWS_SECRET_ACCESS_KEY
 read -p "AWS Region: " AWS_REGION
 
-cd ./apps/deployment
-
 export AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID"
 export AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY"
 export AWS_REGION="$AWS_REGION"
@@ -51,7 +49,11 @@ echo "Building application"
 npm run build
 
 echo "Deploying application"
-npx cdk deploy --all --parameters CodeArtifactDomainName="$CA_DOMAIN" --parameters GithubOrgName="$GH_ORG"
+(cd ./apps/deployment; \
+  npx cdk deploy --all \
+  --parameters StaCodeArtifact:CodeArtifactDomainName="$CA_DOMAIN" \
+  --parameters StaHooks:GithubOrgName="$GH_ORG" \
+)
 
 
 echo "Linking Webhook to Github Org"
@@ -91,4 +93,4 @@ npx nx build dashboard
 cat $tmp_file > ./apps/dashboard/src/environments/environment.prod.ts
 
 echo "Deploy dashboard"
-npx cdk deploy StaDashboard
+(cd ./apps/deployment;  npx cdk deploy StaDashboard)

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,8 @@
 #!/bin/env bash
 
+nvm use
+npm ci
+
 getCfnOutput() {
   aws cloudformation describe-stacks --stack-name "$STACK_NAME" | jq '.Stacks[0].Outputs[]' -c | while read i; do
       Key=`echo "$i" | jq '.OutputKey' --raw-output`
@@ -65,6 +68,7 @@ npm run build
 echo "Deploying application"
 (cd ./apps/deployment; \
   npx cdk deploy --all \
+    --require-approval never \
     --context CodeArtifactDomainName="$CA_DOMAIN" \
     --context GithubOrgName="$GH_ORG" \
 )
@@ -107,6 +111,7 @@ cat $tmp_file > ./apps/dashboard/src/environments/environment.prod.ts
 
 echo "Deploy dashboard"
 (cd ./apps/deployment;  npx cdk deploy DevDashboard \
+    --require-approval never \
     --context CodeArtifactDomainName="$CA_DOMAIN" \
     --context GithubOrgName="$GH_ORG" \
 )

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,103 @@
+#!/bin/env bash
+
+# TODO: use other than bash script, jq is not a unix tool
+
+echo "SETUP"
+
+read -p "Codeartifact domain name: " CA_DOMAIN
+
+read -p "Github Access Token: " GH_TOKEN
+read -p "Github Org Name: " GH_ORG
+
+read -p "AWS Access Key ID: " AWS_ACCESS_KEY_ID
+read -p "AWS Secret Access Key: " AWS_SECRET_ACCESS_KEY
+read -p "AWS Region: " AWS_REGION
+
+cd ./apps/deployment
+
+export AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY"
+export AWS_REGION="$AWS_REGION"
+
+echo "Saving Github token into Secrets Manager"
+aws secretsmanager create-secret --name GITHUB_TOKEN \
+  --secret-string \
+  "{ \"GITHUB_TOKEN\": \"$GH_TOKEN\" }" \
+  --region $AWS_REGION
+# echo "Create secret: \"{ \"GITHUB_TOKEN\": \"$GH_TOKEN\" }\""
+
+echo "Saving AWS Secrets into Secrets Manager"
+aws secretsmanager create-secret --name AWS_SECRETS \
+  --secret-string \
+  "{ \"AWS_ACCESS_KEY_ID\": \"$AWS_ACCESS_KEY_ID\", \"AWS_SECRET_ACCESS_KEY\": \"$AWS_SECRET_ACCESS_KEY\", \"AWS_REGION\": \"$AWS_REGION\" }" \
+  --region $AWS_REGION
+# echo "Create secret: \
+# \"{ \"AWS_ACCESS_KEY_ID\": \"$AWS_ACCESS_KEY_ID\", \"AWS_SECRET_ACCESS_KEY\": \"$AWS_SECRET_ACCESS_KEY\", \"AWS_REGION\": \"$AWS_REGION\" }\""
+
+
+echo "Building application"
+npm run build
+
+echo "Deploying application"
+npx cdk deploy --all --parameters CodeArtifactDomainName="$CA_DOMAIN" --parameters GithubOrgName="$GH_ORG"
+
+
+echo "Linking Webhook to Github Org"
+STACK_NAME="StaHooks"
+KEY="PIPELINE_LINKER_URL"
+PIPELINE_LINKER_URL=""
+aws cloudformation describe-stacks --stack-name "$STACK_NAME" | jq '.Stacks[0].Outputs[]' -c | while read i; do
+    Key=`echo "$i" | jq '.OutputKey' --raw-output`
+    Val=`echo "$i" | jq '.OutputValue' --raw-output`
+    if [ "$Key" = "$KEY" ];
+    then
+      PIPELINE_LINKER_URL="$Val"
+    fi
+done
+if [ $PIPELINE_LINKER_URL -z ];
+then
+    echo "PIPELINE_LINKER_URL CFN_OUTPUT NOT FOUND"
+    exit 1
+fi
+curl -s $PIPELINE_LINKER_URL
+
+echo "Deploying Dashboard"
+STACK_NAME="StaHttp"
+KEY="HTTP_API_URL"
+HTTP_API_URL=""
+aws cloudformation describe-stacks --stack-name "$STACK_NAME" | jq '.Stacks[0].Outputs[]' -c | while read i; do
+    Key=`echo "$i" | jq '.OutputKey' --raw-output`
+    Val=`echo "$i" | jq '.OutputValue' --raw-output`
+    if [ "$Key" = "$KEY" ];
+    then
+      HTTP_API_URL="$Val"
+    fi
+done
+if [ $HTTP_API_URL -z ];
+then
+    echo "HTTP_API_URL CFN_OUTPUT NOT FOUND"
+    exit 1
+fi
+
+tmp_file=`mktemp`
+
+cat ./apps/dashboard/src/environments/environment.prod.ts > $tmp_file
+
+echo "export const environment = {
+  production: true,
+  apiHost: '$HTTP_API_URL',
+};" > ./apps/dashboard/src/environments/environment.prod.ts
+
+echo "Building dashboard with production configurations"
+npx nx build dashboard
+
+cat $tmp_file > ./apps/dashboard/src/environments/environment.prod.ts
+
+echo "Deploy dashboard"
+npx cdk deploy StaDashboard
+
+# Reset the env we fked around with
+export AWS_ACCESS_KEY_ID=""
+export AWS_SECRET_ACCESS_KEY=""
+export AWS_REGION=""
+


### PR DESCRIPTION
- feat(deployment): use cfn params to define github org name and codeartifact domain name
- feat(deployment): create setup script that uses CfnParams define
- build: install s3 deployment cdk lib
- build(dashboard): hardcode lambda url into prod env file
- feat(deployment): define stack for dashboard ui
- refactor: refactor getting cfn output into bash func for setup script
- refactor(deployment): put cfn params in respective stacks
- fix(setup): only chdir in subshells
- refactor(deployment): use context instead of cfn params
- fix(setup): show frontend url after deployment
- feat(setup): set require-approval to never, for more automated deployment
